### PR TITLE
Change rc4 to aes-128-cfb by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## 1.0.1
+
+### Changed
+
+- Default cipher algo changed from `rc4` to `aes-128-cfb`
+
 ## v0.1.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## 1.0.1
+## Unreleased
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ composer require avto-dev/hash-generator-laravel "^1.0"
 <?php
 
 return [
-    'cipher_algo' => 'rc4',
+    'cipher_algo' => 'aes-128-cfb',
     'passphrase'  => 'pass_phrase', // Случайную строку
     'options'     => 0,
 ];

--- a/config/hash-generator.php
+++ b/config/hash-generator.php
@@ -6,7 +6,7 @@ return [
     /**
      * @link https://www.php.net/manual/ru/function.openssl-encrypt.php
      */
-    'cipher_algo' => 'rc4', // @link https://www.php.net/manual/ru/function.openssl-get-cipher-methods.php
+    'cipher_algo' => 'aes-128-cfb', // @link https://www.php.net/manual/ru/function.openssl-get-cipher-methods.php
     'passphrase'  => 'pass_phrase', // @link https://www.php.net/manual/ru/function
 //.openssl-random-pseudo-bytes.php
     'options'     => 0, // @link https://www.php.net/manual/ru/function.openssl-encrypt.php

--- a/src/OpenSslReversibleHash.php
+++ b/src/OpenSslReversibleHash.php
@@ -85,7 +85,8 @@ class OpenSslReversibleHash implements ReversibleHashInterface
             $data,
             $this->cipher_algo,
             $this->passphrase,
-            $this->options
+            $this->options,
+            $this->getInitVector()
         );
 
         if (\is_bool($encrypted_data)) {
@@ -110,7 +111,8 @@ class OpenSslReversibleHash implements ReversibleHashInterface
             $code,
             $this->cipher_algo,
             $this->passphrase,
-            $this->options
+            $this->options,
+            $this->getInitVector()
         );
 
         if (\is_bool($decrypted_data)) {
@@ -118,5 +120,13 @@ class OpenSslReversibleHash implements ReversibleHashInterface
         }
 
         return $decrypted_data;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getInitVector(): string
+    {
+        return \md5($this->passphrase, true);
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -19,7 +19,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             $config = $app->make(Repository::class);
 
             return new OpenSslReversibleHash(
-                $config->get('hash-generator.cipher_algo', 'rc4'),
+                $config->get('hash-generator.cipher_algo', 'aes-128-cfb'),
                 $config->get('hash-generator.passphrase', 'secret'),
                 $config->get('hash-generator.options', 0),
             );

--- a/tests/OpenSslReversibleHashTest.php
+++ b/tests/OpenSslReversibleHashTest.php
@@ -17,23 +17,23 @@ class OpenSslReversibleHashTest extends AbstractTestCase
     public function testGenerate(): void
     {
         $ssl_hash = new OpenSslReversibleHash(
-            'rc4',
+            'aes-128-cfb',
             'salt',
             \OPENSSL_ZERO_PADDING
         );
 
-        $this->assertEquals('TnQvZi9qYkFrb0dVVE44PQ==', $ssl_hash->generate('secret data'));
+        $this->assertEquals('bVFxWmpkekNhS09BTEI0PQ==', $ssl_hash->generate('secret data'));
     }
 
     public function testRegenerate(): void
     {
         $ssl_hash = new OpenSslReversibleHash(
-            'rc4',
+            'aes-128-cfb',
             'salt',
             \OPENSSL_ZERO_PADDING
         );
 
-        $this->assertEquals('secret data', $ssl_hash->regenerate('TnQvZi9qYkFrb0dVVE44PQ=='));
+        $this->assertEquals('secret data', $ssl_hash->regenerate('bVFxWmpkekNhS09BTEI0PQ=='));
     }
 
     public function testRegenerateNormalizationFail(): void
@@ -42,7 +42,7 @@ class OpenSslReversibleHashTest extends AbstractTestCase
         $this->expectExceptionMessage('Hash "#iu3498r" do not normalized');
 
         $ssl_hash = new OpenSslReversibleHash(
-            'rc4',
+            'aes-128-cfb',
             'salt',
             \OPENSSL_ZERO_PADDING
         );


### PR DESCRIPTION
## Description

### Changed

- Default cipher algorithm changed from `rc4` to `aes-128-cfb`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file